### PR TITLE
Breaking: Use scrollView ref directly instead of getNode for RN 0.62

### DIFF
--- a/NativeLargeList.js
+++ b/NativeLargeList.js
@@ -248,11 +248,11 @@ export class NativeLargeList extends React.PureComponent<LargeListPropType> {
   );
 
   setScrollEnabled(enabled) {
-    this._scrollView.current.getNode().setNativeProps({ scrollEnabled: enabled });
+    this._scrollView.current.setNativeProps({ scrollEnabled: enabled });
   }
 
   scrollToEnd(animated = true) {
-    return this._scrollView.current.getNode().scrollToEnd({ animated });
+    return this._scrollView.current.scrollToEnd({ animated });
   }
 
   scrollTo(offset: Offset, animated: boolean = true): Promise<void> {
@@ -264,7 +264,7 @@ export class NativeLargeList extends React.PureComponent<LargeListPropType> {
     );
     idx(() => this._sectionContainer.current.updateOffset(offset.y));
     return new Promise((r, j) => {
-      this._scrollView.current.getNode().scrollTo({ ...offset, animated });
+      this._scrollView.current.scrollTo({ ...offset, animated });
 
       setTimeout(() => {
         r();


### PR DESCRIPTION
Fixes the following warning in RN0.62 

Calling `getNode()` on the ref of an Animated component is no longer necessary. You can now directly use the ref instead. This method will be removed in a future release. ScrollView